### PR TITLE
Update workshop program. Minor 2020 -> 2022 changes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,17 @@
 					.tg .tg-73oq{border-color:#ffffff;text-align:left;vertical-align:middle}
 					.tg table{margin: auto;}
 				</style>
+                <h3>All times below are in Eastern Time</h3>
+                <style type="text/css">
+                    h3 {text-align: center;}
+					.tg  {border-collapse:collapse;border-spacing:0;}
+					.tg td{border-color:black;border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;
+					  overflow:hidden;padding:10px 5px;word-break:normal;}
+					.tg th{border-color:black;border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;
+					  font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
+					.tg .tg-73oq{border-color:#ffffff;text-align:left;vertical-align:middle}
+					.tg table{margin: auto;}
+                </style>
 				<table class="tg" width = "700" align="center">
 					<thead>
 					  <tr>

--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
                         <div class="row">
                             <div class="col-sm-6">
                                 <div class="carousel-content">
-                                    <h2><span>C<font style="text-transform:lowercase">y</font>S<font style="text-transform:lowercase">oc</font></span> 2020<br> International Workshop on <br><span>Cyber Social Threats</span></h2>
-                                    <p>Co-located with the 14th International AAAI Conference on Web and Social Media (<a href="https://www.icwsm.org/2020/index.html">ICWSM 2020</a>). <br><b>Date: June 8, 2020</b> <br> <b>(will be held virtually.) </b></p>
+                                    <h2><span>C<font style="text-transform:lowercase">y</font>S<font style="text-transform:lowercase">oc</font></span> 2022<br> International Workshop on <br><span>Cyber Social Threats</span></h2>
+                                    <p>Co-located with the 16th International AAAI Conference on Web and Social Media (<a href="https://www.icwsm.org/2022/index.html/" target="_blank">ICWSM 2022</a>). <br><b>Date: June 6, 2022</b> <br> <b>Hybrid format (both in-person in Atlanta, Georgia and online) </b></p>
                                     <a class="btn btn-primary btn-lg" href="#features">More</a> <a class="btn btn-primary btn-lg" href="https://aaaiconf.cvent.com/icwsm20"  target="_blank">Registration</a>
 
                                 </div>
@@ -188,14 +188,19 @@
         <div class="container">
             <div class="section-header">
                 <h2 class="section-title text-center wow fadeInDown">Important Dates</h2>
-                <p class="text-center wow fadeInDown"><br>Paper submissions due: <b><del>April 29, 2020</del> May 4, 2020 (Anywhere on Earth)</b><br>
-    Final decision notification: May 27, 2020<br>
-    Camera-ready submissions due: June 3, 2020<br></p>
+                <p class="text-center wow fadeInDown">
+                    <br>Paper submissions due: <b>March 27, 2022 (Anywhere on Earth)</b>
+                    <br>
+                    Final decision notification: April 10, 2022
+                    <br>
+                    Camera-ready submissions due: April 17, 2022
+                    <br>
+                </p>
             </div>
             <div class="section-header">
                 <h2 style="text-align:center">Submission Instructions</h2>
                 <p class="text-center wow fadeInDown"><br>We invite research papers (8 pages), position and short papers (4 pages), and demo papers (2 pages). Submissions must be original and should not have been published previously or be under consideration for publication while being evaluated for this workshop. Submissions will be evaluated by the program committee based on the quality of the work and its fit to the workshop themes. All submissions should be double-blind and a high-resolution PDF of the paper should be uploaded to <a href="https://easychair.org/conferences/?conf=cysoc2020"  target="_blank">the EasyChair submission site</a> before the paper submission deadline. 
-                The accepted papers will be presented at the <span>CySoc</span> workshop integrated with the conference, and they will be published as <a href="http://workshop-proceedings.icwsm.org/"  target="_blank">Proceedings of the ICWSM Workshops</a>. All must be submitted, and formatted in <a href="https://www.aaai.org/Publications/Templates/AuthorKit20.zip"  target="_blank">AAAI two-column, camera-ready style</a>. 
+                The accepted papers will be presented at the <span>CySoc</span> workshop integrated with the conference, and they will be published as <a href="http://workshop-proceedings.icwsm.org/"  target="_blank">Proceedings of the ICWSM Workshops</a>. All must be submitted, and formatted in <a href="https://www.aaai.org/Publications/Templates/AuthorKit22.zip"  target="_blank">AAAI two-column, camera-ready style</a>. 
                 <br></p>
             </div>
 
@@ -221,32 +226,70 @@
 					  <tr>
 						<th class="tg-73oq">
 							<p class="text-center wow fadeInDown" style="text-align:left">
-								<b>8.30 – 8.45 AM – Welcome</b> to the CySoc 2020 workshop attendees. <br>
-								<b>8.45 – 9.45 AM – Keynote I:</b> <a href="https://www.aolteanu.com/"  target="_blank">Alexandra Olteanu</a>, <a href="https://www.microsoft.com/en-us/research/theme/fate/"  target="_blank">Microsoft Research</a>. <br>
-								<p style="margin-left:10%"><b>"Challenges to Measuring Objectionable Behavior Online by Humans and Machines"</b> <br> There is a rich literature on detecting and moderating a wide range of objectionable or deviant content and behaviors online, including hate speech, cyberbullying, trolling, and misinformation.  There is also a growing literature on fairness, accountability, and transparency in computational systems that is concerned with how such systems may inadvertently reinforce and amplify such behaviors, or may even promote or manifest new types of objectionable behaviors.  While many systems have become increasingly proficient at identifying clear cases of objectionable content and behaviors, there are still many persistent issues.  While existing efforts often focus on issues that we know to look for, techniques for preempting future issues that may not yet be on the research community's radar are not nearly as well developed or understood.  In this talk, I will share reflections on why many of these issues continue linger, including due to the reliance on proxy measurements, data generation and collection processes, training and testing datasets construction, and the design of evaluation metrics. </p> <br>
-								<b>9.45 – 10.30 AM – COVID-19 Paper Session:</b> Four papers will be presented with 12 minutes allocated for each, including Q/A.<br>
-								<div style="margin-left:5%">
+								<b>8.30 – 8.45 AM – Welcome</b> the CySoc 2022 workshop attendees.
+                                <br>
+								<b>8.45 – 9.45 AM – Keynote I:</b> <a href="https://physics.columbian.gwu.edu/neil-johnson"  target="_blank">Neil Johnson</a>, <a href="https://www.gwu.edu/"  target="_blank">George Washington University</a>. Title TBA.
+                                <!-- UPDATE ONCE NEIL PROVIDES INFO <br>
+								<p style="margin-left:10%"><b>Title Goes Here</b>
+                                    <br>
+                                    There is a rich literature on detecting and moderating a wide range of objectionable or deviant content and behaviors online, including hate speech, cyberbullying, trolling, and misinformation.  There is also a growing literature on fairness, accountability, and transparency in computational systems that is concerned with how such systems may inadvertently reinforce and amplify such behaviors, or may even promote or manifest new types of objectionable behaviors.  While many systems have become increasingly proficient at identifying clear cases of objectionable content and behaviors, there are still many persistent issues.  While existing efforts often focus on issues that we know to look for, techniques for preempting future issues that may not yet be on the research community's radar are not nearly as well developed or understood.  In this talk, I will share reflections on why many of these issues continue linger, including due to the reliance on proxy measurements, data generation and collection processes, training and testing datasets construction, and the design of evaluation metrics.
+                                </p> -->
+                                <br>
+								<b>9.45 – 10.30 AM – Paper Session I:</b> Three papers will be presented with 12 minutes allocated for each, including Q/A.<br>
+								<!-- UPDATE AFTER PAPERS HAVE BEEN ACCEPTED <div style="margin-left:5%">
 									<ul class="nostyle">
 										<li><i class="fa fa-check-square"></i> Kai-Cheng Yang, Christopher Torres-Lugo and Filippo Menczer: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_16"  target="_blank">“Prevalence of Low-Credibility Information on Twitter During the COVID-19 Outbreak”</a></li>
 										<li><i class="fa fa-check-square"></i> Lynnette Ng and Jia Yuan Loke: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_12"  target="_blank">”Is this pofma? Analysing public opinion and misinformation in a COVID-19 Telegram group chat”</a> <b>***Best Paper</b></li>
 										<li><i class="fa fa-check-square"></i> Gautam Kishore Shahi and Durgesh Nandini: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_14"  target="_blank">“FakeCovid- A Multilingual Cross-domain Fact Check News Dataset for COVID-19”</a></li>
 										<li><i class="fa fa-check-square"></i> Alexei Abrahams and Noura Aljizawi: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_17"  target="_blank">“Middle Eastern Twitter bots and the covid-19 ‘infodemic’”</a></li>
 									</ul>
-								</div>
-								<b>10.30 – 10.45 AM –</b> Coffee Break.  <br>
-								<b>10.45 – 11.45 AM –  Keynote II:</b> <a href="https://www.linkedin.com/in/mikey-cohen-4612a0/"  target="_blank">Mikey Cohen</a>, Director of Engineering at <a href="https://ncri.io/"  target="_blank">the Network Contagion Research Institute</a>, former head of Edge Network Engineering at <a href="https://netflix.com"  target="_blank">Netflix</a>. <br>
-								<p style="margin-left:10%"><b>“Promoted to Zero: Why I choose Fighting Hate Online over Netflix?”</b><br> This talk describes the motivation behind my unexpected career change from being a leader at Netflix to starting a nonprofit. This new foundation, NCRI, not only attempts to identify and understand the root causes of hate but also tries to transform the model of how an institute and nonprofit should run, by bringing in the best of academia, social sciences, and the culture of Silicon Valley. Learn how this institute reframes how a nonprofit should function while seeking to decipher and resolve these seemingly insurmountable and ever changing problems online.</p> <br> 
-								<b>11.45 AM – 12.30 PM – Paper Session:</b> Four papers will be presented with 12 minutes allocated for each, including Q/A. <br>
-								<div style="margin-left:5%">
+								</div> -->
+								<b>10.30 – 10.50 AM –</b> Coffee Break.
+                                <br>
+								<b>10.50 – 12.00 PM –  Panel Discussion:</b>
+                                    <!-- Meeyoung Cha (KAIST, Korea), Ullrich Eckher (The University of Western Australia) -->
+                                    <a href="https://ds.ibs.re.kr/ci/"  target="_blank">Meeyoung Cha</a> (<a href="https://www.kaist.ac.kr/en/"  target="_blank">KAIST</a>, Korea), 
+                                    <a href="https://www.emc-lab.org/"  target="_blank">Ullrich Eckher</a> (<a href="https://www.uwa.edu.au/"  target="_blank">The University of Western Australia</a>).
+                                    <!-- UPDATE WHEN THIRD PANELIST IS CONFIRMED <a href="https://www.emc-lab.org/"  target="_blank">Ullrich Eckher</a> (<a href="https://www.uwa.edu.au/"  target="_blank">The University of Western Australia</a>) -->
+                                <br>
+								<p style="margin-left:5%"><b>"The Impact of Online (Mis)information on Vaccination Programs."</b>
+                                    <br>
+                                    Moderator TBA.
+                                </p>
+                                <!-- <br>  -->
+								<b>12.00 – 12.30 PM – Paper Session II:</b> Two papers will be presented with 12 minutes allocated for each, including Q/A.
+                                <br>
+								<!-- UPDATE AFTER PAPERS HAVE BEEN ACCEPTED <div style="margin-left:5%">
 									<ul class="nostyle">
 										<li><i class="fa fa-check-square"></i> Kimberley R. Allison: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_11"  target="_blank">"Navigating Negativity in Research: Methodological and Ethical Considerations in the Study of Antisocial, Subversive and Toxic Online Communities and Behaviours"</a></li>
 										<li><i class="fa fa-check-square"></i> Emmi Bevensee, Maxwell Aliapoulios, Quinn Dougherty, Jason Baumgartner, Damon McCoy and Jeremy Blackburn: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_18"  target="_blank">"SMAT: The Social Media Analysis Toolkit"</a> </li>
 										<li><i class="fa fa-check-square"></i> Taichi Murayama, Shoko Wakamiya and Eiji Aramaki: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_13"  target="_blank">"Fake News Detection using Temporal Features Extracted via Point Process"</a> </li>
 										<li><i class="fa fa-check-square"></i> Chen Ling and Gianluca Stringhini: <a href="http://workshop-proceedings.icwsm.org/abstract?id=2020_15"  target="_blank">"Examining the Impact of Social Distance on the Reaction to a Tragedy: A Case Study on Sulli’s Death"</a></li>
 									</ul>
-								</div>								
-								<b>12.30 PM – 12.50 PM –  Synthesis/Brainstorming</b> exercise, resulting in paper concepts for impactful future research, 20-minute discussion session. <br>
-								<b>12.50 PM – 1.00 PM –  Closing</b> remarks. <br>
+								</div> -->
+								<b>12.30 – 1.00 PM –</b> Break.
+                                <br>
+                                <b>1.00 – 2.00 PM –  Keynote II:</b> <a href="https://comm.unc.edu/people/department-faculty/alice-e-marwick/"  target="_blank">Alice Marwick</a>, <a href="https://www.unc.edu/"  target="_blank">The University of North Carolina at Chapel Hill</a>. Title TBA.
+                                <br>
+								<b>2.00 PM – 3.00 PM –  Demo presentations</b>: Two demos will be presented with 30 minutes allocated for each, including Q/A.
+                                <br>
+                                <div style="margin-left:5%">
+									<ul class="nostyle">
+										<li><i class="fa fa-check-square"></i> <a href="http://dfreelon.org/"  target="_blank">Dean Freelon</a> (<a href="https://www.unc.edu/"  target="_blank">The University of North Carolina at Chapel Hill</a>): Title TBA</li>
+                                        <li><i class="fa fa-check-square"></i> Demo #2 TBA</li>
+                                        <!-- <li><i class="fa fa-check-square"></i> <a href="http://dfreelon.org/"  target="_blank">Dean Freelon</a>: Title TBA</li> -->
+									</ul>
+								</div>
+                                <b>3.00 – 3.30 PM – Paper Session III:</b> Two papers will be presented, 15 minutes each, including Q/A. 
+                                <br>
+                                <b>3.30 – 3.45 PM –</b> Coffee Break.
+                                <br>
+                                <b>3.45 – 4.30 PM – Keynote III</b> or <b>Paper Session IV</b>.
+                                <br>
+                                <b>4.30 – 5.00 PM –  Synthesis/Brainstorming exercise:</b> 15 minutes, resulting in paper concepts for impactful future research, followed by a 15-minute discussion session. The synthesis part will be in zoom break-out rooms, and the discussion will be in the main room.
+                                <br>
+                                <b>5.00 – 5.15 PM – </b> Closing remarks.
+
 							</p>
 						</th>
 					  </tr>


### PR DESCRIPTION
Most of these updates were to the workshop program outline based on what we have so far. However, there are some other small changes that update things to reference 2022 instead of 2020.

Please review for weird formatting issues. Loading on my end locally seems to look okay.

If everything looks okay, please merge it into the main branch so it goes to the live site.